### PR TITLE
Add Parens To Conditional

### DIFF
--- a/src/thank-you.coffee
+++ b/src/thank-you.coffee
@@ -37,5 +37,5 @@ module.exports = (robot) ->
 
   robot.hear /thanks? (.*)/i, (msg) ->
     name = msg.match[1]
-    if name.toLowerCase().indexOf robot.name.toLowerCase() > -1
+    if (name.toLowerCase().indexOf robot.name.toLowerCase()) > -1
       msg.send msg.random response


### PR DESCRIPTION
Currently, the paren's coffeescript is applying are checking `name.indexOf(robot.name > -1)`, this will almost always eval to -1 and make the conditional pass. 

Adding parens separates the boolean check from the input of `indexOf`