### PR TITLE
Improve the help message

### DIFF
--- a/src/thank-you.coffee
+++ b/src/thank-you.coffee
@@ -10,7 +10,7 @@
 #
 # Commands:
 #   hubot thank[s] [you] - Hubot accepts your thanks
-#   thanks hubot - same
+#   thanks hubot - Hubot accepts your thanks
 #
 # Author:
 #   github.com/delucas


### PR DESCRIPTION
When used with `hubot help` this will show "same" way further down the list of commands from the first one, so the word "same" doesn't make sense.